### PR TITLE
add ability to handle some server downtime without stopping all workers

### DIFF
--- a/cmd/testclient/main.go
+++ b/cmd/testclient/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+
+	defer println("Main Function Returned Here")
+	waitChan := make(chan bool)
+	// stopHeartbeatChan := make(chan bool)
+
+	var isWorking = struct{ active bool }{active: true}
+
+	go MyWork(5, waitChan)
+	go MySleep(15, &isWorking)
+
+	<-waitChan
+	isWorking.active = false
+
+	time.Sleep(5 * time.Second) //wait to see
+
+}
+
+// MySleep sleeps for 1 second in each iteration
+func MySleep(sleepTime int, isWorking *struct{ active bool }) {
+	for i := 0; i < sleepTime; i++ {
+		fmt.Println("goroutine running: ", i)
+		time.Sleep(1 * time.Second)
+		if isWorking.active == false {
+			fmt.Println("done waiting")
+			break
+		}
+	}
+}
+
+// MyWork does actual work
+func MyWork(count time.Duration, c chan bool) {
+	defer println("Work done")
+
+	fmt.Println("Working! ")
+	time.Sleep(count * time.Second)
+
+	c <- true
+}

--- a/cmd/testclient2/main.go
+++ b/cmd/testclient2/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// https://medium.com/geekculture/heartbeats-in-golang-1a12c4c366f
+
+func main() {
+
+	doWork := func(done <-chan interface{}, pulseInterval time.Duration) (<-chan interface{}, <-chan time.Time) {
+
+		heartbeat := make(chan interface{})
+		results := make(chan time.Time)
+
+		go func() {
+			defer close(heartbeat)
+			defer close(results)
+
+			pulse := time.Tick(pulseInterval)
+			workGen := time.Tick(2 * pulseInterval)
+
+			sendPulse := func() {
+				select {
+				case heartbeat <- struct{}{}:
+				default:
+				}
+			}
+			sendResult := func(r time.Time) {
+				for {
+					select {
+					case <-done:
+						return
+					case <-pulse:
+						sendPulse()
+					case results <- r:
+						return
+					}
+				}
+			}
+
+			for {
+				select {
+				case <-done:
+					return
+				case <-pulse:
+					sendPulse()
+				case r := <-workGen:
+					sendResult(r)
+				}
+			}
+		}()
+		return heartbeat, results
+	}
+
+	done := make(chan interface{})
+	time.AfterFunc(10*time.Second, func() { close(done) })
+
+	const timeout = 2 * time.Second
+	heartbeat, results := doWork(done, timeout/2)
+	for {
+		select {
+		case _, ok := <-heartbeat:
+			if ok == false {
+				return
+			}
+			fmt.Println("pulse")
+		case r, ok := <-results:
+			if ok == false {
+				return
+			}
+			fmt.Printf("results %v\n", r.Second())
+		case <-time.After(timeout):
+			return
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/dhrp/moulin
 
-go 1.20
+go 1.21
+
+toolchain go1.23.3
 
 require (
 	github.com/golang/protobuf v1.5.3
@@ -40,6 +42,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.1.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	golang.org/x/crypto v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
+github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
+github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=

--- a/pkg/process/retrypolicy.go
+++ b/pkg/process/retrypolicy.go
@@ -1,0 +1,56 @@
+package process
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type RetryPolicy struct {
+	MethodConfig []MethodConfig `json:"methodConfig"`
+}
+
+type MethodConfig struct {
+	Name         []Name         `json:"name"`
+	WaitForReady bool           `json:"waitForReady"`
+	RetryPolicy  RetryPolicyDef `json:"retryPolicy"`
+}
+
+type Name struct {
+	Service string `json:"service"`
+}
+
+type RetryPolicyDef struct {
+	MaxAttempts          int      `json:"MaxAttempts"`
+	InitialBackoff       string   `json:"InitialBackoff"`
+	MaxBackoff           string   `json:"MaxBackoff"`
+	BackoffMultiplier    float64  `json:"BackoffMultiplier"`
+	RetryableStatusCodes []string `json:"RetryableStatusCodes"`
+}
+
+func main() {
+	policy := RetryPolicy{
+		MethodConfig: []MethodConfig{
+			{
+				Name: []Name{
+					{
+						Service: "grpc.examples.echo.Echo",
+					},
+				},
+				WaitForReady: true,
+				RetryPolicy: RetryPolicyDef{
+					MaxAttempts:          4,
+					InitialBackoff:       ".01s",
+					MaxBackoff:           ".01s",
+					BackoffMultiplier:    1.0,
+					RetryableStatusCodes: []string{"UNAVAILABLE"},
+				},
+			},
+		},
+	}
+
+	jsonPolicy, err := json.MarshalIndent(policy, "", "    ")
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%s\n", jsonPolicy)
+}

--- a/pkg/process/work.go
+++ b/pkg/process/work.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var loadTaskTimeOut = 30 * time.Second
-var heartBeatInterval = 30 * time.Second
-var heartBeatTimeOutSeconds int32 = 300 // 5 minutes
+var loadTaskTimeOut = client.ClientConfig.LoadTaskTimeOut
+var heartBeatInterval = client.ClientConfig.HeartBeatInterval
+var serverUnavailableTimeOut = client.ClientConfig.ServerUnavailableTimeOut
 
 // Work manages getting, heartbeating, and completing or failing
 // items, in a loop
@@ -92,7 +92,11 @@ func RepeatHeartBeat(grpcDriver *client.GRPCDriver, queueID string, taskID strin
 			break
 		}
 
-		grpcDriver.HeartBeat(queueID, taskID, heartBeatTimeOutSeconds)
-		fmt.Println("   heartbeat beat")
+		_, err := grpcDriver.HeartBeat(queueID, taskID)
+		if err != nil {
+			log.Printf("could not complete heartbeat: %v", err)
+		} else {
+			fmt.Println("heartbeat beat")
+		}
 	}
 }

--- a/pkg/rouge/rouge.go
+++ b/pkg/rouge/rouge.go
@@ -205,10 +205,9 @@ func (red *Client) Heartbeat(queueID string, taskID string, expirationSec int32)
 	score := strconv.FormatInt(expiresAt, 10)
 
 	// _, _, _ = set, score, value
-	count, _ := red.zaddUpdate(set, score, member)
-	if count == 0 {
-		errMsg := "Heartbeat: no item could be found to update, was item already " +
-			"completed?, or perhaps the item was updated < 1 sec ago."
+	_, err := red.zaddUpdate(set, score, member)
+	if err != nil {
+		errMsg := "Heartbeat: no item could be found to update, was the item already completed?"
 		log.Println(errMsg)
 		return 0, errors.New(errMsg)
 	}

--- a/pkg/rouge/rouge_test.go
+++ b/pkg/rouge/rouge_test.go
@@ -251,8 +251,13 @@ func (suite *RedClientTestSuite) TestHeartbeatPhase() {
 	suite.Nil(err, "didn't expect an error")
 	suite.NotZero(expires, "expired a non-zero expiry")
 
-	// Here we do a second update, which is expected to fail
-	expires, err = suite.red.Heartbeat(queueID, member, expirationSec)
+	// Here we try to update it again, which should succeed (again)
+	expires2, err := suite.red.Heartbeat(queueID, taskID, expirationSec)
+	suite.Nil(err, "didn't expect an error")
+	suite.NotZero(expires2, "expired a non-zero expiry")
+
+	// Here we try to update a nonexisting member, which is expected to fail
+	expires, err = suite.red.Heartbeat(queueID, "nonexisting", expirationSec)
 	suite.NotNil(err, "I expected an error")
 	suite.Zero(expires, "expired a non-zero expiry")
 }

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -104,7 +104,7 @@ func (s *server) LoadTask(ctx context.Context, in *pb.RequestMessage) (*pb.Task,
 }
 
 // LoadTask returns a task from the redis queue
-func (s *server) HeartBeat(ctx context.Context, in *pb.Task) (*pb.StatusMessage, error) {
+func (s *server) HeartBeat(_ context.Context, in *pb.Task) (*pb.StatusMessage, error) {
 
 	queueID := in.QueueID
 	taskID := in.TaskID
@@ -118,11 +118,9 @@ func (s *server) HeartBeat(ctx context.Context, in *pb.Task) (*pb.StatusMessage,
 
 	expires, err := s.rouge.Heartbeat(queueID, taskID, expirationSec)
 	if err != nil {
-		// ToDo return error to client, it could be because item was just updated
-		log.Println(err)
 		return &pb.StatusMessage{
 			Status: pb.Status_FAILURE,
-			Detail: fmt.Sprintf("Heartbeat failed, task not found or updated in the same second"),
+			Detail: err.Error(), // "usually: item not found",
 		}, nil
 	}
 
@@ -133,7 +131,7 @@ func (s *server) HeartBeat(ctx context.Context, in *pb.Task) (*pb.StatusMessage,
 }
 
 // Complete moves a task from the running to the complete set
-func (s *server) Complete(ctx context.Context, in *pb.Task) (*pb.StatusMessage, error) {
+func (s *server) Complete(_ context.Context, in *pb.Task) (*pb.StatusMessage, error) {
 
 	queueID := in.QueueID
 	taskID := in.TaskID
@@ -150,7 +148,7 @@ func (s *server) Complete(ctx context.Context, in *pb.Task) (*pb.StatusMessage, 
 }
 
 // Fail moves a task from the running queue to the failed set
-func (s *server) Fail(ctx context.Context, in *pb.Task) (*pb.StatusMessage, error) {
+func (s *server) Fail(_ context.Context, in *pb.Task) (*pb.StatusMessage, error) {
 
 	queueID := in.QueueID
 	taskID := in.TaskID
@@ -175,7 +173,7 @@ func (s *server) Progress(ctx context.Context, in *pb.RequestMessage) (*pb.Queue
 	return queueInfo.ToBuff(), nil
 }
 
-func (s *server) ListQueues(ctx context.Context, in *empty.Empty) (*pb.QueueMap, error) {
+func (s *server) ListQueues(_ context.Context, in *empty.Empty) (*pb.QueueMap, error) {
 
 	queueMap := &pb.QueueMap{Queues: make(map[string]*pb.QueueProgress)}
 	queues, err := s.rouge.ListQueues()
@@ -193,7 +191,7 @@ func (s *server) ListQueues(ctx context.Context, in *empty.Empty) (*pb.QueueMap,
 }
 
 // Peek returns a count and messageList
-func (s *server) Peek(ctx context.Context, in *pb.RequestMessage) (*pb.TaskList, error) {
+func (s *server) Peek(_ context.Context, in *pb.RequestMessage) (*pb.TaskList, error) {
 	// var task pb.Task
 	taskList := &pb.TaskList{}
 
@@ -215,7 +213,7 @@ func (s *server) Peek(ctx context.Context, in *pb.RequestMessage) (*pb.TaskList,
 	return taskList, nil
 }
 
-func (s *server) DeleteQueue(ctx context.Context, in *pb.RequestMessage) (*pb.StatusMessage, error) {
+func (s *server) DeleteQueue(_ context.Context, in *pb.RequestMessage) (*pb.StatusMessage, error) {
 	queueID := in.QueueID
 
 	taskCount, err := s.rouge.DeleteQueue(queueID)

--- a/pkg/server/grpc_test.go
+++ b/pkg/server/grpc_test.go
@@ -15,7 +15,7 @@ import (
 func (suite *ServerTestSuite) TestHealthz() {
 	req := &empty.Empty{}
 	resp, _ := suite.server.Healthz(context.Background(), req)
-	suite.NotEmpty(resp, "didnt get a response")
+	suite.NotEmpty(resp, "didn't get a response")
 }
 
 func (suite *ServerTestSuite) TestPushLoadAndCompleteTask() {


### PR DESCRIPTION
This should add a retry policy on heartbeat, complete, fail and some other tasks. So that a server reboot cannot do much harm. 

defaults:
```
LoadTaskTimeOut:           30 * time.Second,
HeartBeatInterval:         2 * time.Minute,
ServerUnavailableTimeOut:  1 * time.Hour,
TaskExpirationTime:        5 * time.Minute,
MaxBetweenCompleteRetries: 1 * time.Minute,
```
Also fixes a bug where, if the heartbeat updates an item with the same score (unix timestamp second), the heartbeat 'fails' where it was really a success.


closes #7